### PR TITLE
Fix rule id not in rule range

### DIFF
--- a/plugins/auto-decoding-config.conf
+++ b/plugins/auto-decoding-config.conf
@@ -36,7 +36,7 @@
 # SecRule line with an unconditional SecAction statement.
 #
 #SecRule &TX:auto-decoding-plugin_enabled "@eq 0" \
-#  "id:95001010,\
+#  "id:9501010,\
 #   phase:1,\
 #   pass,\
 #   nolog,\


### PR DESCRIPTION
This fixes an invalid rule id. The rule id 95001010 is not inside the rule id range from "9,501,000 - 9,501,999". This PR fixes the rule id 