### PR TITLE
Fix: reintroduced double decoding config variable

### DIFF
--- a/plugins/auto-decoding-before.conf
+++ b/plugins/auto-decoding-before.conf
@@ -208,8 +208,10 @@ SecRule ARGS "!@streq %{ARGS}" \
     nolog,\
     setvar:'tx.tf_1_utf8toUnicode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-SecRule &TX:DOUBLE_DECODING "@eq 0" "id:9501060,phase:2,pass,nolog,skipAfter:END-auto-decoding-before"
 
+SecRule &TX:AUTO-DECODING-PLUGIN_DOUBLE_DECODING "@eq 0" "id:9501060,phase:2,pass,nolog,skipAfter:END-auto-decoding-before"
+
+        
 # Transformation: base64DecodeExt
 SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     "id:9501400,\

--- a/plugins/auto-decoding-config.conf
+++ b/plugins/auto-decoding-config.conf
@@ -41,3 +41,11 @@
 #   pass,\
 #   nolog,\
 #   setvar:'tx.auto-decoding-plugin_enabled=0'"
+
+# Uncomment to enable double decoding of parameters
+#SecAction \
+#  "id:9501020,\
+#   phase:1,\
+#   pass,\
+#   nolog,\
+#   setvar:'tx.auto-decoding-plugin_double_decoding=1'"


### PR DESCRIPTION
This fixes https://github.com/coreruleset/auto-decoding-plugin/issues/4