### PR TITLE
feat: redo target list for CRS4

### DIFF
--- a/plugins/auto-decoding-after.conf
+++ b/plugins/auto-decoding-after.conf
@@ -19,19 +19,21 @@
 # Please read the documentation about automatic decoding in the README.md file
 # of the plugin.
 
+# Automatic list
+# $ grep -E -A2 "^SecRule.*ARGS(_GET|_POST)?[|\ ]" ~/rules/* | grep -v "SecRule\|phase\|\"@[a-z]\|--" | cut -d: -f2 | tr -d ',\\'  | sort -n  | sed -e "s/^/SecRuleUpdateTargetById /" -e "s/$/ TX:\/^tf_\//"
 
-SecRuleUpdateTargetById 913120 TX:/^tf_/
 SecRuleUpdateTargetById 920230 TX:/^tf_/
-SecRuleUpdateTargetById 920250 TX:/^tf_/
 SecRuleUpdateTargetById 920270 TX:/^tf_/
 SecRuleUpdateTargetById 920271 TX:/^tf_/
 SecRuleUpdateTargetById 920272 TX:/^tf_/
 SecRuleUpdateTargetById 920273 TX:/^tf_/
-SecRuleUpdateTargetById 920370 TX:/^tf_/
+SecRuleUpdateTargetById 920380 TX:/^tf_/
 SecRuleUpdateTargetById 920460 TX:/^tf_/
 SecRuleUpdateTargetById 921110 TX:/^tf_/
 SecRuleUpdateTargetById 921120 TX:/^tf_/
 SecRuleUpdateTargetById 921130 TX:/^tf_/
+SecRuleUpdateTargetById 921151 TX:/^tf_/
+SecRuleUpdateTargetById 921160 TX:/^tf_/
 SecRuleUpdateTargetById 921200 TX:/^tf_/
 SecRuleUpdateTargetById 930100 TX:/^tf_/
 SecRuleUpdateTargetById 930110 TX:/^tf_/
@@ -39,21 +41,36 @@ SecRuleUpdateTargetById 930120 TX:/^tf_/
 SecRuleUpdateTargetById 931100 TX:/^tf_/
 SecRuleUpdateTargetById 931120 TX:/^tf_/
 SecRuleUpdateTargetById 931130 TX:/^tf_/
-SecRuleUpdateTargetById 932100 TX:/^tf_/
-SecRuleUpdateTargetById 932101 TX:/^tf_/
-SecRuleUpdateTargetById 932105 TX:/^tf_/
-SecRuleUpdateTargetById 932106 TX:/^tf_/
-SecRuleUpdateTargetById 932106 TX:/^tf_/
-SecRuleUpdateTargetById 932110 TX:/^tf_/
-SecRuleUpdateTargetById 932115 TX:/^tf_/
 SecRuleUpdateTargetById 932120 TX:/^tf_/
+SecRuleUpdateTargetById 932125 TX:/^tf_/
 SecRuleUpdateTargetById 932130 TX:/^tf_/
 SecRuleUpdateTargetById 932140 TX:/^tf_/
-SecRuleUpdateTargetById 932150 TX:/^tf_/
 SecRuleUpdateTargetById 932160 TX:/^tf_/
 SecRuleUpdateTargetById 932171 TX:/^tf_/
+SecRuleUpdateTargetById 932175 TX:/^tf_/
 SecRuleUpdateTargetById 932190 TX:/^tf_/
 SecRuleUpdateTargetById 932200 TX:/^tf_/
+SecRuleUpdateTargetById 932210 TX:/^tf_/
+SecRuleUpdateTargetById 932220 TX:/^tf_/
+SecRuleUpdateTargetById 932230 TX:/^tf_/
+SecRuleUpdateTargetById 932231 TX:/^tf_/
+SecRuleUpdateTargetById 932232 TX:/^tf_/
+SecRuleUpdateTargetById 932235 TX:/^tf_/
+SecRuleUpdateTargetById 932236 TX:/^tf_/
+SecRuleUpdateTargetById 932238 TX:/^tf_/
+SecRuleUpdateTargetById 932240 TX:/^tf_/
+SecRuleUpdateTargetById 932250 TX:/^tf_/
+SecRuleUpdateTargetById 932260 TX:/^tf_/
+SecRuleUpdateTargetById 932300 TX:/^tf_/
+SecRuleUpdateTargetById 932301 TX:/^tf_/
+SecRuleUpdateTargetById 932310 TX:/^tf_/
+SecRuleUpdateTargetById 932311 TX:/^tf_/
+SecRuleUpdateTargetById 932320 TX:/^tf_/
+SecRuleUpdateTargetById 932321 TX:/^tf_/
+SecRuleUpdateTargetById 932330 TX:/^tf_/
+SecRuleUpdateTargetById 932331 TX:/^tf_/
+SecRuleUpdateTargetById 932370 TX:/^tf_/
+SecRuleUpdateTargetById 932380 TX:/^tf_/
 SecRuleUpdateTargetById 933100 TX:/^tf_/
 SecRuleUpdateTargetById 933120 TX:/^tf_/
 SecRuleUpdateTargetById 933130 TX:/^tf_/
@@ -68,7 +85,16 @@ SecRuleUpdateTargetById 933180 TX:/^tf_/
 SecRuleUpdateTargetById 933190 TX:/^tf_/
 SecRuleUpdateTargetById 933200 TX:/^tf_/
 SecRuleUpdateTargetById 933210 TX:/^tf_/
+SecRuleUpdateTargetById 933211 TX:/^tf_/
 SecRuleUpdateTargetById 934100 TX:/^tf_/
+SecRuleUpdateTargetById 934101 TX:/^tf_/
+SecRuleUpdateTargetById 934110 TX:/^tf_/
+SecRuleUpdateTargetById 934120 TX:/^tf_/
+SecRuleUpdateTargetById 934130 TX:/^tf_/
+SecRuleUpdateTargetById 934140 TX:/^tf_/
+SecRuleUpdateTargetById 934150 TX:/^tf_/
+SecRuleUpdateTargetById 934160 TX:/^tf_/
+SecRuleUpdateTargetById 934170 TX:/^tf_/
 SecRuleUpdateTargetById 941100 TX:/^tf_/
 SecRuleUpdateTargetById 941110 TX:/^tf_/
 SecRuleUpdateTargetById 941120 TX:/^tf_/
@@ -78,6 +104,7 @@ SecRuleUpdateTargetById 941150 TX:/^tf_/
 SecRuleUpdateTargetById 941160 TX:/^tf_/
 SecRuleUpdateTargetById 941170 TX:/^tf_/
 SecRuleUpdateTargetById 941180 TX:/^tf_/
+SecRuleUpdateTargetById 941181 TX:/^tf_/
 SecRuleUpdateTargetById 941190 TX:/^tf_/
 SecRuleUpdateTargetById 941200 TX:/^tf_/
 SecRuleUpdateTargetById 941210 TX:/^tf_/
@@ -98,12 +125,15 @@ SecRuleUpdateTargetById 941350 TX:/^tf_/
 SecRuleUpdateTargetById 941360 TX:/^tf_/
 SecRuleUpdateTargetById 941370 TX:/^tf_/
 SecRuleUpdateTargetById 941380 TX:/^tf_/
+SecRuleUpdateTargetById 941390 TX:/^tf_/
+SecRuleUpdateTargetById 941400 TX:/^tf_/
 SecRuleUpdateTargetById 942100 TX:/^tf_/
-SecRuleUpdateTargetById 942110 TX:/^tf_/
 SecRuleUpdateTargetById 942120 TX:/^tf_/
 SecRuleUpdateTargetById 942130 TX:/^tf_/
+SecRuleUpdateTargetById 942131 TX:/^tf_/
 SecRuleUpdateTargetById 942140 TX:/^tf_/
 SecRuleUpdateTargetById 942150 TX:/^tf_/
+SecRuleUpdateTargetById 942151 TX:/^tf_/
 SecRuleUpdateTargetById 942160 TX:/^tf_/
 SecRuleUpdateTargetById 942170 TX:/^tf_/
 SecRuleUpdateTargetById 942180 TX:/^tf_/
@@ -145,17 +175,35 @@ SecRuleUpdateTargetById 942490 TX:/^tf_/
 SecRuleUpdateTargetById 942500 TX:/^tf_/
 SecRuleUpdateTargetById 942510 TX:/^tf_/
 SecRuleUpdateTargetById 942511 TX:/^tf_/
+SecRuleUpdateTargetById 942520 TX:/^tf_/
+SecRuleUpdateTargetById 942521 TX:/^tf_/
+SecRuleUpdateTargetById 942522 TX:/^tf_/
+SecRuleUpdateTargetById 942530 TX:/^tf_/
+SecRuleUpdateTargetById 942540 TX:/^tf_/
+SecRuleUpdateTargetById 942550 TX:/^tf_/
+SecRuleUpdateTargetById 942560 TX:/^tf_/
 SecRuleUpdateTargetById 943100 TX:/^tf_/
 SecRuleUpdateTargetById 944100 TX:/^tf_/
 SecRuleUpdateTargetById 944110 TX:/^tf_/
 SecRuleUpdateTargetById 944120 TX:/^tf_/
 SecRuleUpdateTargetById 944130 TX:/^tf_/
+SecRuleUpdateTargetById 944150 TX:/^tf_/
+SecRuleUpdateTargetById 944151 TX:/^tf_/
+SecRuleUpdateTargetById 944152 TX:/^tf_/
 SecRuleUpdateTargetById 944200 TX:/^tf_/
 SecRuleUpdateTargetById 944210 TX:/^tf_/
 SecRuleUpdateTargetById 944240 TX:/^tf_/
 SecRuleUpdateTargetById 944250 TX:/^tf_/
+SecRuleUpdateTargetById 944260 TX:/^tf_/
 SecRuleUpdateTargetById 944300 TX:/^tf_/
 
+# Manual List
+# CAVEAT: there is a misbehavior with ModSecurity v2, where a target update in a chain
+# is being applied to all the rules in a chain. We accept that even if it can lead to FPs.
+
+SecRuleUpdateTargetById 920250:1 TX:/^tf_/
+SecRuleUpdateTargetById 920370:1 TX:/^tf_/
+SecRuleUpdateTargetById 920540:1 TX:/^tf_/
 
 # The following rules generally lead to false positives with the decoded files.
 # They are thus excluded automatically for the decoded / transformed parameters.

--- a/plugins/auto-decoding-before.conf
+++ b/plugins/auto-decoding-before.conf
@@ -208,8 +208,10 @@ SecRule ARGS "!@streq %{ARGS}" \
     nolog,\
     setvar:'tx.tf_1_utf8toUnicode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-SecRule &TX:DOUBLE_DECODING "@eq 0" "id:9501060,phase:2,pass,nolog,skipAfter:END-auto-decoding-before"
 
+SecRule &TX:AUTO-DECODING-PLUGIN_DOUBLE_DECODING "@eq 0" "id:9501060,phase:2,pass,nolog,skipAfter:END-auto-decoding-before"
+
+        
 # Transformation: base64DecodeExt
 SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     "id:9501400,\

--- a/plugins/auto-decoding-config.conf
+++ b/plugins/auto-decoding-config.conf
@@ -41,3 +41,11 @@
 #   pass,\
 #   nolog,\
 #   setvar:'tx.auto-decoding-plugin_enabled=0'"
+
+# Uncomment to enable double decoding of parameters
+#SecAction \
+#  "id:9501020,\
+#   phase:1,\
+#   pass,\
+#   nolog,\
+#   setvar:'tx.auto-decoding-plugin_double_decoding=1'"


### PR DESCRIPTION
Lots of rules and targets have changed.

This is the necessary update for CRS4.

Rules that were removed for CRS4 and are thus no longer part of the rule set (-> 930xxx for example)  were removed from the target list too. This results in a CRS4 auto-decode-plugin.